### PR TITLE
Add compatibility support for ALTER TABLE containing AFTER command

### DIFF
--- a/query_alter.class.php
+++ b/query_alter.class.php
@@ -281,6 +281,7 @@ class AlterQuery {
 		$tokenized_query = $queries;
 		if (stripos($tokenized_query['command'], 'add column') !== false) {
 			$column_def = $this->convert_field_types($tokenized_query['column_name'], $tokenized_query['column_def']);
+			$column_def = preg_replace('/ AFTER.*/im', '', $column_def);
 			$query = "ALTER TABLE {$tokenized_query['table_name']} ADD COLUMN {$tokenized_query['column_name']} $column_def";
 		} elseif (stripos($tokenized_query['command'], 'rename') !== false) {
 			$query = "ALTER TABLE {$tokenized_query['table_name']} RENAME TO {$tokenized_query['column_name']}";

--- a/utilities/test-sql.php
+++ b/utilities/test-sql.php
@@ -1,0 +1,9 @@
+<?php
+
+include("../query_alter.class.php");
+
+$alter = new AlterQuery();
+
+var_dump($alter->rewrite_query("ALTER TABLE `wp_redirection_items` ADD `match_url` VARCHAR(2000) NULL DEFAULT NULL AFTER `url`","ALTER"));
+
+?>


### PR DESCRIPTION
Hello,

I had some issue with the latest version of the Redirection plugin that uses the AFTER keyword on a ALTER TABLE command. As it is unsupported by SQLite the whole query was rejected.

This patch removes the AFTER keyword to be SQLite compliant. The new column will not be inserted at the intended location but the plugins will work.

Best regards,