### PR TITLE
fix array offset access with curly braces deprecation

### DIFF
--- a/pdoengine.class.php
+++ b/pdoengine.class.php
@@ -785,10 +785,10 @@ class PDOEngine extends PDO {
 		$param = trim($param);
 
 		//remove the quotes at the end and the beginning
-		if (in_array($param{strlen($param)-1}, array("'",'"'))) {
+		if (in_array($param[strlen($param)-1], array("'",'"'))) {
 			$param = substr($param,0,-1) ;//end
 		}
-		if (in_array($param{0}, array("'",'"'))) {
+		if (in_array($param[0], array("'",'"'))) {
 			$param = substr($param, 1); //start
 		}
 		//$this->extracted_variables[] = $param;


### PR DESCRIPTION
`Deprecated: Array and string offset access syntax with curly braces is deprecated in wordpress\wp-content\plugins\sqlite-integration\pdoengine.class.php on line 788`
`Deprecated: Array and string offset access syntax with curly braces is deprecated in wordpress\wp-content\plugins\sqlite-integration\pdoengine.class.php on line 791`

php 7.4

```
$ php --version
PHP 7.4.11 (cli) (built: Sep 29 2020 13:17:42) ( NTS Visual C++ 2017 x64 )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.11, Copyright (c), by Zend Technologies
    with Xdebug v2.9.8, Copyright (c) 2002-2020, by Derick Rethans
```